### PR TITLE
Enable tab switching to work

### DIFF
--- a/src/declarativewebcontainer.cpp
+++ b/src/declarativewebcontainer.cpp
@@ -1054,13 +1054,13 @@ void DeclarativeWebContainer::sendVkbOpenCompositionMetrics()
 
 void DeclarativeWebContainer::createGLContext()
 {
-    qWarning() << "Multiple tabs are not yet working!!!";
-    Q_ASSERT(!m_context);
-
-    m_context = new QOpenGLContext();
-    m_context->setFormat(requestedFormat());
-    m_context->create();
-    m_context->makeCurrent(this);
-
-    initializeOpenGLFunctions();
+    if (!m_context) {
+        m_context = new QOpenGLContext();
+        m_context->setFormat(requestedFormat());
+        m_context->create();
+        m_context->makeCurrent(this);
+        initializeOpenGLFunctions();
+    } else {
+        m_context->makeCurrent(this);
+    }
 }

--- a/src/pages/BrowserPage.qml
+++ b/src/pages/BrowserPage.qml
@@ -135,10 +135,10 @@ Page {
 
     InputRegion {
         window: webView.chromeWindow
-        y: webView.enabled && browserPage.active ? overlay.y : 0
+        y: webView.enabled && browserPage.active && !webView.popupActive ? overlay.y : 0
 
         width: browserPage.width
-        height: webView.enabled && browserPage.active ? browserPage.height - overlay.y : browserPage.height
+        height: webView.enabled && browserPage.active && !webView.popupActive ? browserPage.height - overlay.y : browserPage.height
     }
 
     Rectangle {

--- a/src/pages/BrowserPage.qml
+++ b/src/pages/BrowserPage.qml
@@ -53,6 +53,14 @@ Page {
     // if input method is not visible.
     clip: status != PageStatus.Active || webView.inputPanelVisible
 
+    onStatusChanged: {
+        if (status >= PageStatus.Activating && status <= PageStatus.Active) {
+            overlay.animator.showChrome()
+        } else {
+            overlay.animator.hide()
+        }
+    }
+
     orientationTransitions: Transition {
         to: 'Portrait,Landscape,PortraitInverted,LandscapeInverted'
         from: 'Portrait,Landscape,PortraitInverted,LandscapeInverted'

--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -59,9 +59,12 @@ PanelBackground {
     }
 
     function enterNewTabUrl(action) {
-        if (webView.contentItem) {
-            webView.contentItem.opacity = 0.0
-        }
+        // TODO: Figure out what to do with content opacity. Remove before merging.
+        // As browser content window is the window at background we cannot really fade it away.
+        // Maybe we just need to keep opacity in 1.0 when overlay is raised regardless of the case.
+//        if (webView.contentItem) {
+//            webView.contentItem.opacity = 0.0
+//        }
 
         searchField.enteringNewTabUrl = true
         searchField.resetUrl("")

--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -97,7 +97,7 @@ PanelBackground {
 
     color: "black"
     gradient: null
-//        Gradient {
+//    gradient: Gradient {
 //        GradientStop { position: 0.0; color: Theme.rgba(Theme.highlightBackgroundColor, 0.3) }
 //        GradientStop { position: 1.0; color: Theme.rgba(Theme.highlightBackgroundColor, 0.0) }
 //    }
@@ -425,6 +425,11 @@ PanelBackground {
                 if (activeWebPage && status == PageStatus.Active) {
                     webView.privateMode ? activeWebPage.grabThumbnail() : activeWebPage.grabToFile()
                 }
+            }
+
+            Rectangle {
+                color: "black"
+                anchors.fill: parent
             }
 
             Browser.TabView {

--- a/src/pages/components/WebPopupHandler.js
+++ b/src/pages/components/WebPopupHandler.js
@@ -13,6 +13,7 @@
 .import QtQuick 2.1 as QtQuick
 .import Sailfish.Browser 1.0 as Browser
 
+var browserPage
 var webView
 var popups
 var pageStack
@@ -49,7 +50,7 @@ var _authData = null
 
 function _hideVirtualKeyboard() {
     if (Qt.inputMethod.visible) {
-        webView.parent.focus = true
+        browserPage.focus = true
     }
 }
 
@@ -144,6 +145,7 @@ function openContextMenu(data) {
         var imageSrc = data.mediaURL
         var linkTitle = data.linkTitle
         var contentType = data.contentType
+
         if (_contextMenu) {
             _contextMenu.linkHref = linkHref
             _contextMenu.linkTitle = linkTitle.trim()
@@ -153,7 +155,7 @@ function openContextMenu(data) {
         } else {
             contextMenuComponent = Qt.createComponent(_contextMenuComponentUrl)
             if (contextMenuComponent.status !== QtQuick.Component.Error) {
-                _contextMenu = contextMenuComponent.createObject(webView.parent,
+                _contextMenu = contextMenuComponent.createObject(browserPage,
                                                         {
                                                             "linkHref": linkHref,
                                                             "imageSrc": imageSrc,

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -342,6 +342,7 @@ WebContainer {
         PopupHandler.auxTimer = auxTimer
         PopupHandler.pageStack = pageStack
         PopupHandler.webView = webView
+        PopupHandler.browserPage = browserPage
         PopupHandler.resourceController = resourceController
         PopupHandler.WebUtils = WebUtils
         PopupHandler.tabModel = tabModel


### PR DESCRIPTION
This is not perfect, bugs exists.

Wrong parent was used from ContextMenu creation, let's use browser page as a parent.

One commit fixes Context menu to work again.
