### PR TITLE
Don't mess view active state from QML layer.

### DIFF
--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -73,14 +73,6 @@ WebContainer {
             toolbarHeight: container.toolbarHeight
 
             enabled: webView.enabled
-            // Active could pause e.g. video in cover by anding
-            // Qt.application.active to visible
-            // TODO: This should still be futher investigated.
-            // Guarding of suspend/resume & gc combo
-            // Page loading should finish even if it would be at background.
-            // Slow network (2G). Maybe we need something like
-            // suspend() { if (loaded) { suspendView() } } for suspend calls.
-            active: visible || activeWebPage
 
             // There needs to be enough content for enabling chrome gesture
             chromeGestureThreshold: toolbarHeight / 2


### PR DESCRIPTION
In new multi-windowed browser setup where all web pages are rendered
into one window it's very important to manage QOpenGLWebPage::active
state consitently. The best place to do so seems to be
WebPages::updateStates function. Unfortunately this was not the only
place messing with view active state. The property was also modified
from QML layer. In some cases (opening link in new tab) the QML layer
could activate web page which was just deactivated from
Webpages::updateStates leading to two pages being active at the same
time.

This patch removes the QML code messing with active state of the view.
Without it I can no longer find a usage scenario where two pages could
be left active at the same time.

Ref: JB#28807
