### PR TITLE
[sailfish-browser] Use gecko pref system for enabling external window…

### DIFF
--- a/src/declarativewebutils.cpp
+++ b/src/declarativewebutils.cpp
@@ -192,6 +192,8 @@ void DeclarativeWebUtils::updateWebEngineSettings()
 
     // Don't force 16bit color depth
     mozContext->setPref(QString("gfx.qt.rgb16.force"), QVariant(false));
+    // Use external Qt window for rendering content
+    mozContext->setPref(QString("gfx.compositor.external-window"), QVariant(true));
 
     mozContext->setPref(QString("media.resource_handler_disabled"), QVariant(true));
 

--- a/src/sailfishbrowser.cpp
+++ b/src/sailfishbrowser.cpp
@@ -49,7 +49,6 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
 {
     setenv("USE_ASYNC", "1", 1);
     setenv("USE_NEMO_GSTREAMER", "1", 1);
-    setenv("MOZ_USE_EXTERNAL_WINDOW", "1", 1);
 
     // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=929879
     setenv("LC_NUMERIC", "C", 1);


### PR DESCRIPTION
… feature. JB#28807

The recent update for gecko-dev made the external window rendering
feature use gecko prefs system. Right now to enalbe external window
rendering the user should set gfx.compositor.external-window pref
instead of exporting MOZ_USE_EXTERNAL_WINDOW env variable. This patch
addjusts sailfish-browser to the new setup.
