### PR TITLE
Window state fixes

### DIFF
--- a/src/declarativewebcontainer.cpp
+++ b/src/declarativewebcontainer.cpp
@@ -240,11 +240,6 @@ void DeclarativeWebContainer::setPrivateMode(bool privateMode)
     }
 }
 
-bool DeclarativeWebContainer::background() const
-{
-    return m_webPage ? m_webPage->background() : false;
-}
-
 bool DeclarativeWebContainer::loading() const
 {
     if (m_webPage) {
@@ -467,7 +462,6 @@ bool DeclarativeWebContainer::activatePage(int tabId, bool force, int parentId)
         connect(m_webPage, SIGNAL(loadProgressChanged()), this, SLOT(updateLoadProgress()), Qt::UniqueConnection);
         connect(m_webPage, SIGNAL(titleChanged()), this, SLOT(onPageTitleChanged()), Qt::UniqueConnection);
         connect(m_webPage, SIGNAL(domContentLoadedChanged()), this, SLOT(sendVkbOpenCompositionMetrics()), Qt::UniqueConnection);
-        connect(m_webPage, SIGNAL(backgroundChanged()), this, SIGNAL(backgroundChanged()), Qt::UniqueConnection);
         connect(m_webPage, SIGNAL(requestGLContext()), this, SLOT(createGLContext()), Qt::DirectConnection);
         return activationData.activated;
     }

--- a/src/declarativewebcontainer.cpp
+++ b/src/declarativewebcontainer.cpp
@@ -111,6 +111,7 @@ DeclarativeWebContainer::DeclarativeWebContainer(QWindow *parent)
     qApp->installEventFilter(this);
 
     showFullScreen();
+    connect(this, SIGNAL(windowStateChanged(Qt::WindowState)), this, SLOT(updateWindowState(Qt::WindowState)));
 }
 
 DeclarativeWebContainer::~DeclarativeWebContainer()
@@ -610,6 +611,13 @@ void DeclarativeWebContainer::updateContentOrientation(Qt::ScreenOrientation ori
     }
 
     reportContentOrientationChange(orientation);
+}
+
+void DeclarativeWebContainer::updateWindowState(Qt::WindowState windowState)
+{
+    if (m_webPage && windowState >= Qt::WindowMaximized) {
+        m_webPage->update();
+    }
 }
 
 void DeclarativeWebContainer::imeNotificationChanged(int state, bool open, int cause, int focusChange, const QString &type)

--- a/src/declarativewebcontainer.h
+++ b/src/declarativewebcontainer.h
@@ -185,6 +185,7 @@ public slots:
 
 private slots:
     void updateContentOrientation(Qt::ScreenOrientation orientation);
+    void updateWindowState(Qt::WindowState windowState);
     void imeNotificationChanged(int state, bool open, int cause, int focusChange, const QString& type);
     void handleEnabledChanged();
     void initialize();

--- a/src/declarativewebcontainer.h
+++ b/src/declarativewebcontainer.h
@@ -51,7 +51,6 @@ class DeclarativeWebContainer : public QWindow, public QQmlParserStatus, protect
     Q_PROPERTY(qreal inputPanelHeight READ inputPanelHeight WRITE setInputPanelHeight NOTIFY inputPanelHeightChanged FINAL)
     Q_PROPERTY(qreal inputPanelOpenHeight MEMBER m_inputPanelOpenHeight NOTIFY inputPanelOpenHeightChanged FINAL)
     Q_PROPERTY(qreal toolbarHeight MEMBER m_toolbarHeight NOTIFY toolbarHeightChanged FINAL)
-    Q_PROPERTY(bool background READ background NOTIFY backgroundChanged FINAL)
     Q_PROPERTY(bool allowHiding MEMBER m_allowHiding NOTIFY allowHidingChanged FINAL)
 
     Q_PROPERTY(QString favicon MEMBER m_favicon NOTIFY faviconChanged)
@@ -90,8 +89,6 @@ public:
 
     bool privateMode() const;
     void setPrivateMode(bool);
-
-    bool background() const;
 
     bool loading() const;
 
@@ -137,7 +134,6 @@ signals:
     void completedChanged();
     void enabledChanged();
     void foregroundChanged();
-    void backgroundChanged();
     void allowHidingChanged();
     void maxLiveTabCountChanged();
     void popupActiveChanged();

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -330,7 +330,6 @@ WebContainer {
     }
 
     Component.onCompleted: {
-        console.log("---------------------------------------------------------- TERVE!!!")
         PopupHandler.auxTimer = auxTimer
         PopupHandler.pageStack = pageStack
         PopupHandler.webView = webView

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -146,8 +146,8 @@ WebContainer {
                 }
 
                 // Refresh timers (if any) keep working even for suspended views. Hence
-                // suspend the view again explicitly if app window is in background.
-                if (loaded && webView.background) {
+                // suspend the view again explicitly if browser content window is in not visible (background).
+                if (loaded && !webView.visible) {
                     suspendView();
                 }
 
@@ -318,7 +318,7 @@ WebContainer {
 
     property var resourceController: ResourceController {
         webView: contentItem
-        background: webView.background
+        background: !webView.visible
     }
 
     property Timer auxTimer: Timer {


### PR DESCRIPTION
- Schedule update for the web content when browser window raised to the foreground
- ~~Pass background state correctly to the openglwebpage. Web page is at background only when browser is covered by another application, so not yet in the switcher. Previously this used to be connected inside of mozview => will move this there window is now known by the openglwebpage.~~
- Moved backgrounding handling to the browser content window side

See also https://github.com/tmeshkova/qtmozembed/pull/129
