### PR TITLE
[sailfish-browser] Fix contentHeight change handling and focus out. J…

### DIFF
--- a/rpm/sailfish-browser.spec
+++ b/rpm/sailfish-browser.spec
@@ -1,7 +1,7 @@
 Name:       sailfish-browser
 
 Summary:    Sailfish Browser
-Version:    1.2.1
+Version:    1.3.0
 Release:    1
 Group:      Applications/Internet
 License:    MPLv2
@@ -11,7 +11,7 @@ BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Gui)
 BuildRequires:  pkgconfig(Qt5Quick)
-BuildRequires:  pkgconfig(qt5embedwidget) >= 1.9.4
+BuildRequires:  pkgconfig(qt5embedwidget) >= 1.12.17
 BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Concurrent)
 BuildRequires:  pkgconfig(Qt5Sql)
@@ -23,10 +23,11 @@ BuildRequires:  qt5-qttools-linguist
 BuildRequires:  gdb
 BuildRequires:  oneshot
 
-Requires: sailfishsilica-qt5 >= 0.13.44
+Requires: sailfishsilica-qt5 >= 0.20.61
 Requires: jolla-ambient >= 0.4.18
-Requires: xulrunner-qt5 >= 29.0.1.9
+Requires: xulrunner-qt5 >= 31.7.0.10
 Requires: embedlite-components-qt5 >= 1.6.4
+Requires: qtmozembed-qt5 >= 1.12.17
 Requires: sailfish-browser-settings = %{version}
 Requires: qt5-plugin-imageformat-ico
 Requires: qt5-plugin-imageformat-gif

--- a/src/declarativewebcontainer.h
+++ b/src/declarativewebcontainer.h
@@ -47,9 +47,7 @@ class DeclarativeWebContainer : public QWindow, public QQmlParserStatus, protect
     Q_PROPERTY(bool portrait MEMBER m_portrait NOTIFY portraitChanged FINAL)
     Q_PROPERTY(bool fullscreenMode MEMBER m_fullScreenMode NOTIFY fullscreenModeChanged FINAL)
     Q_PROPERTY(qreal fullscreenHeight MEMBER m_fullScreenHeight NOTIFY fullscreenHeightChanged FINAL)
-    Q_PROPERTY(bool inputPanelVisible READ inputPanelVisible NOTIFY inputPanelVisibleChanged FINAL)
-    Q_PROPERTY(qreal inputPanelHeight READ inputPanelHeight WRITE setInputPanelHeight NOTIFY inputPanelHeightChanged FINAL)
-    Q_PROPERTY(qreal inputPanelOpenHeight MEMBER m_inputPanelOpenHeight NOTIFY inputPanelOpenHeightChanged FINAL)
+    Q_PROPERTY(bool imOpened MEMBER m_imOpened NOTIFY imOpenedChanged FINAL)
     Q_PROPERTY(qreal toolbarHeight MEMBER m_toolbarHeight NOTIFY toolbarHeightChanged FINAL)
     Q_PROPERTY(bool allowHiding MEMBER m_allowHiding NOTIFY allowHidingChanged FINAL)
 
@@ -95,10 +93,7 @@ public:
     int loadProgress() const;
     void setLoadProgress(int loadProgress);
 
-    bool inputPanelVisible() const;
-
-    qreal inputPanelHeight() const;
-    void setInputPanelHeight(qreal height);
+    bool imOpened() const;
 
     bool canGoForward() const;
     void setCanGoForward(bool canGoForward);
@@ -121,6 +116,9 @@ public:
     Q_INVOKABLE void reload(bool force = true);
     Q_INVOKABLE void goForward();
     Q_INVOKABLE void goBack();
+
+    Q_INVOKABLE void updatePageFocus(bool focus);
+
     Q_INVOKABLE bool alive(int tabId);
 
     Q_INVOKABLE void dumpPages() const;
@@ -140,9 +138,7 @@ signals:
     void portraitChanged();
     void fullscreenModeChanged();
     void fullscreenHeightChanged();
-    void inputPanelVisibleChanged();
-    void inputPanelHeightChanged();
-    void inputPanelOpenHeightChanged();
+    void imOpenedChanged();
     void toolbarHeightChanged();
 
     void faviconChanged();
@@ -183,7 +179,6 @@ private slots:
     void updateContentOrientation(Qt::ScreenOrientation orientation);
     void updateWindowState(Qt::WindowState windowState);
     void imeNotificationChanged(int state, bool open, int cause, int focusChange, const QString& type);
-    void handleEnabledChanged();
     void initialize();
     void onActiveTabChanged(int oldTabId, int activeTabId, bool loadActiveTab);
     void onDownloadStarted();
@@ -236,8 +231,7 @@ private:
     bool m_fullScreenMode;
     bool m_activatingTab;
     qreal m_fullScreenHeight;
-    bool m_inputPanelVisible;
-    qreal m_inputPanelHeight;
+    bool m_imOpened;
     qreal m_inputPanelOpenHeight;
     qreal m_toolbarHeight;
 

--- a/src/declarativewebpage.cpp
+++ b/src/declarativewebpage.cpp
@@ -236,9 +236,10 @@ void DeclarativeWebPage::forceChrome(bool forcedChrome)
 
 void DeclarativeWebPage::resetHeight(bool respectContentHeight)
 {
-//    if (!state().isEmpty()) {
-//        return;
-//    }
+    // Input panel is fully open.
+    if (m_container->imOpened()) {
+        return;
+    }
 
     // fullscreen() below in the fullscreen request coming from the web content.
     if (respectContentHeight && (!m_forcedChrome || fullscreen())) {

--- a/src/pages/BrowserPage.qml
+++ b/src/pages/BrowserPage.qml
@@ -12,7 +12,7 @@
 
 import QtQuick 2.1
 import Sailfish.Silica 1.0
-import Sailfish.Silica.private 1.0
+import Sailfish.Silica.private 1.0 as Private
 import Sailfish.Browser 1.0
 import "components" as Browser
 
@@ -144,12 +144,29 @@ Page {
         id: historyModel
     }
 
-    Item {
-//        id: background
-//        anchors.fill: parent
-//        visible: !webView.contentItem
-//        color: webView.contentItem && webView.contentItem.bgcolor ? webView.contentItem.bgcolor : "white"
+    Private.VirtualKeyboardObserver {
+        id: virtualKeyboardObserver
+
+        active: webView.enabled
+        transpose: window._transpose
+        orientation: browserPage.orientation
+
         onWindowChanged: webView.chromeWindow = window
+        onClosedChanged: {
+            if (closed) {
+                webView.updatePageFocus(false)
+            }
+        }
+
+        // Update content height only after virtual keyboard fully opened.
+        states: State {
+            name: "boundHeightControl"
+            when: virtualKeyboardObserver.opened && webView.enabled
+            PropertyChanges {
+                target: webView.contentItem
+                height: browserPage.height - virtualKeyboardObserver.panelSize
+            }
+        }
     }
 
     Browser.DownloadRemorsePopup { id: downloadPopup }
@@ -164,6 +181,7 @@ Page {
         width: window.width
         height: window.height
         rotationHandler: browserPage
+        imOpened: virtualKeyboardObserver.opened
 
         tabModel.onCountChanged: window.solidBackground = tabModel.count == 0
     }
@@ -228,7 +246,7 @@ Page {
     }
 
     CoverActionList {
-        enabled: browserPage.status === PageStatus.Active && webView.contentItem && (Config.sailfishVersion >= 2.0)
+        enabled: browserPage.status === PageStatus.Active && webView.contentItem && (Private.Config.sailfishVersion >= 2.0)
         iconBackground: true
 
         CoverAction {
@@ -239,7 +257,7 @@ Page {
 
     // TODO: remove once we move to sailfish 2.0
     CoverActionList {
-        enabled: browserPage.status === PageStatus.Active && webView.contentItem && (Config.sailfishVersion < 2.0)
+        enabled: browserPage.status === PageStatus.Active && webView.contentItem && (Private.Config.sailfishVersion < 2.0)
         iconBackground: true
 
         CoverAction {

--- a/src/pages/components/FavoriteItem.qml
+++ b/src/pages/components/FavoriteItem.qml
@@ -13,7 +13,7 @@ import QtQuick 2.0
 import Sailfish.Silica 1.0
 
 BackgroundItem {
-    readonly property bool showContextMenu: down && _pressAndHold && browserPage.webView.inputPanelHeight === 0
+    readonly property bool showContextMenu: down && _pressAndHold && window.pageStack.panelSize === 0
     property bool _pressAndHold
 
     layer.effect: PressEffect {}

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -46,8 +46,6 @@ WebContainer {
 
     foreground: Qt.application.active
     allowHiding: !resourceController.videoActive && !resourceController.audioActive
-    inputPanelHeight: window.pageStack.panelSize
-    inputPanelOpenHeight: window.pageStack.imSize
     fullscreenMode: (contentItem && contentItem.chromeGestureEnabled && !contentItem.chrome) ||
                     (contentItem && contentItem.fullscreen)
 
@@ -76,15 +74,13 @@ WebContainer {
 
             // There needs to be enough content for enabling chrome gesture
             chromeGestureThreshold: toolbarHeight / 2
-            chromeGestureEnabled: (contentHeight > fullscreenHeight + toolbarHeight) && !forcedChrome
+            chromeGestureEnabled: (contentHeight > fullscreenHeight + toolbarHeight) && !forcedChrome && enabled && !webView.imOpened
 
             signal selectionRangeUpdated(variant data)
             signal selectionCopied(variant data)
             signal contextMenuRequested(variant data)
 
-//            focus: true
             width: container.rotationHandler && container.rotationHandler.width || 0
-//            state: ""
 
             onClearGrabResult: tabModel.updateThumbnailPath(tabId, "")
             onGrabResult: tabModel.updateThumbnailPath(tabId, fileName)
@@ -267,20 +263,9 @@ WebContainer {
                 }
             }
 
-//            Behavior on opacity { FadeAnimation {} }
-
             // We decided to disable "text selection" until we understand how it
             // should look like in Sailfish.
             // TextSelectionController {}
-//            states: State {
-//                name: "boundHeightControl"
-//                when: container.inputPanelVisible && container.enabled
-//                PropertyChanges {
-//                    target: webPage
-//                    // was floor
-//                    height: Math.ceil(container.parent.height)
-//                }
-//            }
         }
     }
 


### PR DESCRIPTION
…B#28016

Reset contentHeight only after virtual keyboard fully opened. Clear
focus from the web page when virtual keyboard is fully closed.

This will require a small change to Silica in order to work completely
as the ApplicationWindow animates virtual keyboard only if ApplicationWindow
has active focus. Now that we have two windows ApplicationWindow (chrome)
does not have focus when focusing html input field.

Requires: https://github.com/tmeshkova/qtmozembed/pull/130
