### PR TITLE
[sailfish-browser] Suspend active web page when closing web content w…

### DIFF
--- a/src/declarativewebcontainer.cpp
+++ b/src/declarativewebcontainer.cpp
@@ -466,6 +466,10 @@ bool DeclarativeWebContainer::eventFilter(QObject *obj, QEvent *event)
     // Hiding stops rendering. Don't pass it through if hiding is not allowed.
     if (event->type() == QEvent::Expose && !isExposed() && !m_allowHiding) {
         return true;
+    } else if (event->type() == QEvent::Close && m_webPage) {
+	// Make sure gecko does not use GL context we gave it in ::createGLContext
+	// after the window has been closed.
+	m_webPage->suspendView();
     }
     return QObject::eventFilter(obj, event);
 }


### PR DESCRIPTION
…indow JB#29265

Since the GL context we create in DeclarativeWebContainer::createGLContext
is used by gecko internally we must ensure the engine will not try to use
it after the web content window is closed. This is precisely what
QOpenGLWebpage::suspendView allows us to do.
