### PR TITLE
[sailfish-browser] Add fader on top of the web content. Contributes to JB#29100

### DIFF
--- a/src/browser.qml
+++ b/src/browser.qml
@@ -10,7 +10,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import QtQuick 2.0
+import QtQuick 2.2
 import Sailfish.Silica 1.0
 import Sailfish.Browser 1.0
 import "pages"
@@ -18,7 +18,7 @@ import "pages"
 ApplicationWindow {
     id: window
 
-    property bool solidBackground
+    property bool opaqueBackground
 
     signal newTab
 
@@ -51,7 +51,7 @@ ApplicationWindow {
             z: -1
             width: window.width
             height: window.height
-            opacity: window.solidBackground ? 1.0 : 0.0
+            opacity: window.opaqueBackground ? 1.0 : 0.0
             visible: opacity > 0.0
             color: "white"
 

--- a/src/declarativewebcontainer.cpp
+++ b/src/declarativewebcontainer.cpp
@@ -289,7 +289,6 @@ void DeclarativeWebContainer::setChromeWindow(QObject *chromeWindow)
             m_chromeWindow->setTransientParent(this);
             m_chromeWindow->showFullScreen();
             updateContentOrientation(m_chromeWindow->contentOrientation());
-            connect(m_chromeWindow, SIGNAL(contentOrientationChanged(Qt::ScreenOrientation)), this, SLOT(updateContentOrientation(Qt::ScreenOrientation)));
         }
         emit chromeWindowChanged();
     }

--- a/src/declarativewebcontainer.h
+++ b/src/declarativewebcontainer.h
@@ -174,9 +174,9 @@ protected:
 
 public slots:
     void resetHeight(bool respectContentHeight = true);
+    void updateContentOrientation(Qt::ScreenOrientation orientation);
 
 private slots:
-    void updateContentOrientation(Qt::ScreenOrientation orientation);
     void updateWindowState(Qt::WindowState windowState);
     void imeNotificationChanged(int state, bool open, int cause, int focusChange, const QString& type);
     void initialize();

--- a/src/pages/components/OrientationFader.qml
+++ b/src/pages/components/OrientationFader.qml
@@ -1,0 +1,92 @@
+/****************************************************************************
+**
+** Copyright (C) 2015 Jolla Ltd.
+** Contact: Raine Makelainen <raine.makelainen@jolla.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.2
+import Sailfish.Silica 1.0
+
+Rectangle {
+    id: orientationFader
+
+    property alias orientationTransition: transition
+    property alias page: propertyAction.target
+    property alias fadeTarget: fadeOut.target
+    readonly property alias running: transition.running
+
+    signal applyContentOrientation
+
+    anchors.fill: parent
+    opacity: running ? 1.0 : 0.0
+
+    Behavior on opacity {
+        FadeAnimation {
+            alwaysRunToEnd: true
+            duration: 100
+        }
+    }
+
+    Transition {
+        id: transition
+
+        to: 'Portrait,Landscape,PortraitInverted,LandscapeInverted'
+        from: 'Portrait,Landscape,PortraitInverted,LandscapeInverted'
+
+        SequentialAnimation {
+            PropertyAction {
+                id: propertyAction
+                property: 'orientationTransitionRunning'
+                value: true
+            }
+
+            ParallelAnimation {
+                FadeAnimation {
+                    id: fadeOut
+                    to: 0
+                    duration: 100
+                }
+            }
+
+            PropertyAction {
+                target: page
+                properties: 'width,height,rotation,orientation'
+            }
+
+            ScriptAction {
+                script: orientationFader.applyContentOrientation()
+            }
+
+            ScriptAction {
+                script: {
+                    // Restores the Bindings to width, height and rotation
+                    page._defaultTransition = false
+                    page._defaultTransition = true
+                }
+            }
+
+            ParallelAnimation {
+                FadeAnimation {
+                    target: fadeTarget
+                    to: 1
+                    duration: 200
+                }
+
+                // End-2-end implementation for OnUpdateDisplayPort should
+                // give better solution and reduce visible relayoutting.
+                PauseAnimation { duration: 700 }
+            }
+
+            PropertyAction {
+                target: page
+                property: 'orientationTransitionRunning'
+                value: false
+            }
+        }
+    }
+}

--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -24,6 +24,7 @@ Background {
     property alias toolBar: toolBar
     property alias progressBar: progressBar
     property alias animator: overlayAnimator
+    property alias dragArea: dragArea
     readonly property alias enteringNewTabUrl: searchField.enteringNewTabUrl
 
     property var enteredPage
@@ -138,15 +139,6 @@ Background {
         source: "image://theme/graphic-gradient-edge"
     }
 
-    Browser.ProgressBar {
-        id: progressBar
-        width: parent.width
-        height: toolBar.toolsHeight
-        visible: !firstUseOverlay && !searchField.enteringNewTabUrl
-        opacity: webView.loading ? 1.0 : 0.0
-        progress: webView.loadProgress / 100.0
-    }
-
     MouseArea {
         id: dragArea
 
@@ -181,6 +173,15 @@ Background {
 
                 overlayAnimator.drag()
             }
+        }
+
+        Browser.ProgressBar {
+            id: progressBar
+            width: parent.width
+            height: toolBar.toolsHeight
+            visible: !firstUseOverlay && !searchField.enteringNewTabUrl
+            opacity: webView.loading ? 1.0 : 0.0
+            progress: webView.loadProgress / 100.0
         }
 
         Item {


### PR DESCRIPTION
Fader is used to reduce flickering during orientation change. It fades
in with background color of the web page when rotation transition
starts. At the end of the orientation change transition pauses for 700ms
giving web engine a bit of time to relayout.

Content orientation is updated to the browser content window immediately
when fader has faded in.
