### PR TITLE
Dummy glClear upon browser content window exposed

### DIFF
--- a/src/declarativewebcontainer.cpp
+++ b/src/declarativewebcontainer.cpp
@@ -28,6 +28,8 @@
 #include <QScreen>
 #include <QMetaMethod>
 
+#include <QOpenGLFunctions_ES2>
+
 #include <qmozcontext.h>
 #include <QGuiApplication>
 
@@ -66,6 +68,7 @@ DeclarativeWebContainer::DeclarativeWebContainer(QWindow *parent)
     , m_completed(false)
     , m_initialized(false)
     , m_privateMode(m_settingManager->autostartPrivateBrowsing())
+    , m_hasBeenExposed(false)
 {
 
     QSize screenSize = QGuiApplication::primaryScreen()->size();
@@ -463,8 +466,28 @@ QObject *DeclarativeWebContainer::focusObject() const
 bool DeclarativeWebContainer::eventFilter(QObject *obj, QEvent *event)
 {
     // Hiding stops rendering. Don't pass it through if hiding is not allowed.
-    if (event->type() == QEvent::Expose && !isExposed() && !m_allowHiding) {
-        return true;
+    if (event->type() == QEvent::Expose) {
+        if (isExposed() && !m_hasBeenExposed) {
+            QMutexLocker lock(&m_exposedMutex);
+            QOpenGLContext context;
+            context.setFormat(requestedFormat());
+            context.create();
+            context.makeCurrent(this);
+
+            QOpenGLFunctions_ES2* funcs = context.versionFunctions<QOpenGLFunctions_ES2>();
+            if (funcs) {
+                funcs->glClearColor(1.0, 1.0, 1.0, 0.0);
+                funcs->glClear(GL_COLOR_BUFFER_BIT);
+            }
+
+            context.swapBuffers(this);
+            context.doneCurrent();
+            m_hasBeenExposed = true;
+            m_windowExposed.wakeAll();
+
+        } else if (!isExposed() && !m_allowHiding) {
+            return true;
+        }
     } else if (event->type() == QEvent::Close && m_webPage) {
         // Make sure gecko does not use GL context we gave it in ::createGLContext
         // after the window has been closed.
@@ -1014,6 +1037,11 @@ void DeclarativeWebContainer::sendVkbOpenCompositionMetrics()
 
 void DeclarativeWebContainer::createGLContext()
 {
+    QMutexLocker lock(&m_exposedMutex);
+    if (!m_hasBeenExposed) {
+        m_windowExposed.wait(&m_exposedMutex);
+    }
+
     if (!m_context) {
         m_context = new QOpenGLContext();
         m_context->setFormat(requestedFormat());

--- a/src/declarativewebcontainer.cpp
+++ b/src/declarativewebcontainer.cpp
@@ -292,6 +292,7 @@ void DeclarativeWebContainer::setChromeWindow(QObject *chromeWindow)
             m_chromeWindow->setTransientParent(this);
             m_chromeWindow->showFullScreen();
             updateContentOrientation(m_chromeWindow->contentOrientation());
+            connect(m_chromeWindow, SIGNAL(contentOrientationChanged(Qt::ScreenOrientation)), this, SLOT(updateContentOrientation(Qt::ScreenOrientation)));
         }
         emit chromeWindowChanged();
     }
@@ -695,6 +696,7 @@ void DeclarativeWebContainer::initialize()
         emit completedChanged();
     }
     m_initialized = true;
+    disconnect(m_chromeWindow, SIGNAL(contentOrientationChanged(Qt::ScreenOrientation)), this, SLOT(updateContentOrientation(Qt::ScreenOrientation)));
 }
 
 void DeclarativeWebContainer::onDownloadStarted()

--- a/src/declarativewebcontainer.h
+++ b/src/declarativewebcontainer.h
@@ -26,6 +26,9 @@
 #include <QQuickView>
 #include <QQuickItem>
 
+#include <QMutex>
+#include <QWaitCondition>
+
 class QInputMethodEvent;
 class QTimerEvent;
 class DeclarativeTabModel;
@@ -258,6 +261,10 @@ private:
     bool m_initialized;
 
     bool m_privateMode;
+    bool m_hasBeenExposed;
+
+    QMutex m_exposedMutex;
+    QWaitCondition m_windowExposed;
 
     friend class tst_webview;
 };


### PR DESCRIPTION
Contains two commits:
- Create a dummy glContext, glClear, and swap when browser content
  window is exposed inside the gui thread. This way we do not need to wait
  gecko compositor thread.
- Disconnect from chrome window's contentOrientationChanged
  when window is ready to load a page.
