### PR TITLE
[sailfish-browser] Reduce blending in tabspage

### DIFF
--- a/src/browser.qml
+++ b/src/browser.qml
@@ -57,17 +57,4 @@ ApplicationWindow {
         property: "mainWindow"
         value: webView
     }
-
-    data: [
-        Rectangle {
-            z: -1
-            width: window.width
-            height: window.height
-            opacity: window.opaqueBackground ? 1.0 : 0.0
-            visible: opacity > 0.0
-            color: "white"
-
-            Behavior on opacity { FadeAnimation {} }
-        }
-    ]
 }

--- a/src/pages/BrowserPage.qml
+++ b/src/pages/BrowserPage.qml
@@ -181,12 +181,14 @@ Page {
         height: inputMask.height
     }
 
-    Rectangle {
+    Browser.DimmerEffect {
         id: contentDimmer
+        dimmerOpacity: 0.9 - (overlay.y / (webView.fullscreenHeight - overlay.toolBar.toolsHeight)) * 0.9
+        baseOpacity: window.opaqueBackground ? 1 : 0
         width: browserPage.width
         height: Math.ceil(overlay.y)
-        opacity: 0.9 - (overlay.y / (webView.fullscreenHeight - overlay.toolBar.toolsHeight)) * 0.9
-        color: Theme.highlightDimmerColor
+
+        Behavior on baseOpacity { FadeAnimation { property: "baseOpacity" } }
 
         MouseArea {
             anchors.fill: parent
@@ -223,6 +225,9 @@ Page {
 
     Browser.Overlay {
         id: overlay
+
+        baseColor: contentDimmer.baseColor
+        baseOpacity: contentDimmer.baseOpacity
 
         active: browserPage.status == PageStatus.Active
         webView: webView

--- a/src/pages/BrowserPage.qml
+++ b/src/pages/BrowserPage.qml
@@ -183,12 +183,12 @@ Page {
 
     Browser.DimmerEffect {
         id: contentDimmer
-        dimmerOpacity: 0.9 - (overlay.y / (webView.fullscreenHeight - overlay.toolBar.toolsHeight)) * 0.9
-        baseOpacity: window.opaqueBackground ? 1 : 0
         width: browserPage.width
         height: Math.ceil(overlay.y)
 
-        Behavior on baseOpacity { FadeAnimation { property: "baseOpacity" } }
+        baseColor: overlay.baseColor
+        baseOpacity: overlay.baseOpacity
+        dimmerOpacity: 0.9 - (overlay.y / (webView.fullscreenHeight - overlay.toolBar.toolsHeight)) * 0.9
 
         MouseArea {
             anchors.fill: parent
@@ -225,9 +225,6 @@ Page {
 
     Browser.Overlay {
         id: overlay
-
-        baseColor: contentDimmer.baseColor
-        baseOpacity: contentDimmer.baseOpacity
 
         active: browserPage.status == PageStatus.Active
         webView: webView

--- a/src/pages/components/Background.qml
+++ b/src/pages/components/Background.qml
@@ -11,17 +11,63 @@
 
 import QtQuick 2.2
 import Sailfish.Silica 1.0
-import Sailfish.Silica.private 1.0 as Private
 import "." as Browser
 
-Rectangle {
-    color: "black"
-    opacity: 0.8
+Item {
+    id: wallpaper
 
-    Private.Wallpaper {
+    Item {
+        id: glassTextureItem
+        visible: false
+        width: glassTextureImage.width
+        height: glassTextureImage.height
+
+        Rectangle {
+            color: "black"
+            opacity: 0.948
+            anchors.fill: parent
+            Image {
+                id: glassTextureImage
+                opacity: 0.1
+                source: "image://theme/graphic-shader-texture"
+            }
+        }
+    }
+
+    ShaderEffect {
+        id: wallpaperEffect
         anchors.fill: parent
-        source: ""
-        glassOnly: true
-        effect.blending: true
+
+        // glass texture size
+        property size glassTextureSizeInv: Qt.size(1.0/(glassTextureImage.sourceSize.width),
+                                                   -1.0/(glassTextureImage.sourceSize.height))
+
+        property variant glassTexture: ShaderEffectSource {
+            hideSource: true
+            sourceItem: glassTextureItem
+            wrapMode: ShaderEffectSource.Repeat
+        }
+
+        blending: false
+
+        vertexShader: "
+           uniform highp mat4 qt_Matrix;
+           attribute highp vec4 qt_Vertex;
+
+           void main() {
+              gl_Position = qt_Matrix * qt_Vertex;
+           }
+        "
+
+        fragmentShader: "
+           uniform sampler2D glassTexture;
+           uniform highp vec2 glassTextureSizeInv;
+           uniform lowp float qt_Opacity;
+
+           void main() {
+              lowp vec4 tx = texture2D(glassTexture, gl_FragCoord.xy * glassTextureSizeInv);
+              gl_FragColor = tx;
+           }
+        "
     }
 }

--- a/src/pages/components/Background.qml
+++ b/src/pages/components/Background.qml
@@ -16,8 +16,8 @@ import "." as Browser
 Item {
     id: wallpaper
 
-    property alias baseColor: base.color
-    property alias baseOpacity: base.opacity
+    readonly property alias baseColor: base.color
+    readonly property alias baseOpacity: base.opacity
 
     Item {
         id: glassTextureItem
@@ -29,7 +29,8 @@ Item {
             id: base
             anchors.fill: parent
             color: "white"
-            opacity: 0
+            opacity: window.opaqueBackground ? 1 : 0
+            Behavior on opacity { FadeAnimation { } }
         }
 
         Rectangle {

--- a/src/pages/components/Background.qml
+++ b/src/pages/components/Background.qml
@@ -16,6 +16,9 @@ import "." as Browser
 Item {
     id: wallpaper
 
+    property alias baseColor: base.color
+    property alias baseOpacity: base.opacity
+
     Item {
         id: glassTextureItem
         visible: false
@@ -23,14 +26,22 @@ Item {
         height: glassTextureImage.height
 
         Rectangle {
+            id: base
+            anchors.fill: parent
+            color: "white"
+            opacity: 0
+        }
+
+        Rectangle {
             color: "black"
             opacity: 0.948
             anchors.fill: parent
-            Image {
-                id: glassTextureImage
-                opacity: 0.1
-                source: "image://theme/graphic-shader-texture"
-            }
+        }
+
+        Image {
+            id: glassTextureImage
+            opacity: 0.1
+            source: "image://theme/graphic-shader-texture"
         }
     }
 

--- a/src/pages/components/DimmerEffect.qml
+++ b/src/pages/components/DimmerEffect.qml
@@ -1,0 +1,55 @@
+/****************************************************************************
+**
+** Copyright (C) 2013 Jolla Ltd.
+** Contact: Mikko Harju <mikko.harju@jolla.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.2
+import Sailfish.Silica 1.0
+
+/*
+ Two-color opaque background dimmer. Consists of
+    - baseColor + baseOpacity as background color
+    - dimmerColor + dimmerOpacity blended on top of background color
+ */
+
+ShaderEffect {
+    property color dimmerColor: Theme.highlightDimmerColor
+    property real dimmerOpacity
+
+    property color baseColor: "white"
+    property real baseOpacity
+
+    blending: false
+    visible: dimmerOpacity > 0.0 || baseOpacity > 0.0
+
+    vertexShader: "
+         uniform lowp float baseOpacity;
+         uniform lowp float dimmerOpacity;
+         uniform lowp vec4 baseColor;
+         uniform lowp vec4 dimmerColor;
+         uniform highp mat4 qt_Matrix;
+         attribute highp vec4 qt_Vertex;
+
+         varying lowp vec4 color;
+
+         void main() {
+          lowp vec4 base = baseColor * baseOpacity;
+          lowp vec4 dimmer = dimmerColor * dimmerOpacity;
+          color = base + dimmer*(1.0 - base.a);
+          gl_Position = qt_Matrix * qt_Vertex;
+         }
+    "
+
+    fragmentShader: "
+         varying lowp vec4 color;
+         void main() {
+            gl_FragColor = color;
+         }
+    "
+}


### PR DESCRIPTION
Replace two fullscreen blended quads with a single
opaque-with-alpha shader effect.
