### PR TITLE
[sailfish-browser] Fixed favorite grid context menu resizing when VKB…

### DIFF
--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -352,8 +352,10 @@ Background {
             Browser.HistoryList {
                 id: historyList
 
+                property int panelSize: favoriteGrid.contextMenu && favoriteGrid.contextMenu.active ? 0 : virtualKeyboardObserver.panelSize
+
                 width: parent.width
-                height: browserPage.height - dragArea.drag.minimumY - virtualKeyboardObserver.panelSize
+                height: browserPage.height - dragArea.drag.minimumY - panelSize
 
                 header: Item {
                     width: parent.width


### PR DESCRIPTION
… is open. Contributes to JB#28495
