### PR TITLE
[sailfish-browser] Animate toolbar after browser page is fully visible. Contributes to JB#29685

### DIFF
--- a/src/pages/BrowserPage.qml
+++ b/src/pages/BrowserPage.qml
@@ -80,10 +80,10 @@ Page {
             return
         }
 
-        if (status >= PageStatus.Activating && status <= PageStatus.Active) {
-            overlay.animator.showChrome()
-        } else {
+        if (status == PageStatus.Inactive && overlay.visible) {
             overlay.animator.hide()
+        } else if (status == PageStatus.Active && webView.contentItem && !overlay.enteringNewTabUrl && !webView.contentItem.fullscreen) {
+            overlay.animator.showChrome()
         }
     }
 

--- a/src/pages/components/OverlayAnimator.qml
+++ b/src/pages/components/OverlayAnimator.qml
@@ -203,7 +203,7 @@ Item {
                             webView.contentItem.chrome = animator.state !== "fullscreenWebPage"
                         }
                         _immediate = false
-                        overlay.visible = animator.state !== "fullscreenWebPage"
+                        overlay.visible = animator.state !== "fullscreenWebPage" && animator.state !== "noOverlay"
                     }
                 }
             }


### PR DESCRIPTION
Reduce parallel motion animations so that we don't have vertical and horizontal animations on going.

Review @mikkoharju @rojkov ?
