### PR TITLE
[sailfish-browser] Suspend rendering while keeping timers running for window opener

### DIFF
--- a/rpm/sailfish-browser.spec
+++ b/rpm/sailfish-browser.spec
@@ -25,7 +25,7 @@ BuildRequires:  oneshot
 
 Requires: sailfishsilica-qt5 >= 0.21.10
 Requires: jolla-ambient >= 0.4.18
-Requires: xulrunner-qt5 >= 31.7.0.15
+Requires: xulrunner-qt5 >= 31.7.0.16
 Requires: embedlite-components-qt5 >= 1.8.5
 Requires: qtmozembed-qt5 >= 1.12.18
 Requires: sailfish-browser-settings = %{version}

--- a/src/webpages.cpp
+++ b/src/webpages.cpp
@@ -175,6 +175,10 @@ void WebPages::updateStates(DeclarativeWebPage *oldActivePage, DeclarativeWebPag
                 oldActivePage->stop();
             }
             oldActivePage->suspendView();
+        } else {
+            // Sets parent to inactive and suspends rendering keeping
+            // timeouts running.
+            oldActivePage->setActive(false);
         }
     }
 


### PR DESCRIPTION
Also requires xulrunner-qt5 31.7.0.16 to be tested
