### PR TITLE
[sailfish-browser] Change page background handling to follow page container.  Fixes JB#29662

### DIFF
--- a/src/browser.qml
+++ b/src/browser.qml
@@ -46,7 +46,7 @@ ApplicationWindow {
     _defaultPageOrientations: Orientation.All
     _defaultLabelFormat: Text.PlainText
     _clippingItem.opacity: 1.0
-    _resizeContent: false
+    _resizeContent: !window.rootPage.active
     cover: null
     initialPage: Component {
         BrowserPage {
@@ -114,8 +114,8 @@ ApplicationWindow {
                 }
             }
 
-            width: pageContainer ? pageContainer.width : 0
-            height: pageContainer ? pageContainer.height : 0
+            width: height
+            height: Math.max(Screen.height, Screen.width)
             x: pageContainer && page && page.isPortrait ? pageContainer.x : 0
             y: pageContainer && page && page.isLandscape ? pageContainer.y : 0
             // Page can have longer life-cycle than page container in case

--- a/src/browser.qml
+++ b/src/browser.qml
@@ -15,11 +15,15 @@ import QtQuick.Window 2.1
 import Sailfish.Silica 1.0
 import Sailfish.Browser 1.0
 import "pages"
+import "pages/components" as Browser
 
 ApplicationWindow {
     id: window
 
     property bool opaqueBackground
+    property var rootPage
+
+    property var backgrounds: []
 
     function setBrowserCover(model) {
         if (!model || model.count === 0) {
@@ -27,6 +31,15 @@ ApplicationWindow {
         } else {
             cover = null
         }
+    }
+
+    function findBackgroundIndexByPage(page) {
+        for (var i = 0; i < backgrounds.length; ++i) {
+            if (backgrounds[i].page === page) {
+                return i
+            }
+        }
+        return -1
     }
 
     allowedOrientations: defaultAllowedOrientations
@@ -37,7 +50,32 @@ ApplicationWindow {
     cover: null
     initialPage: Component {
         BrowserPage {
-            Component.onCompleted: window.webView = webView
+            id: browserPage
+
+            Component.onCompleted: {
+                window.webView = webView
+                window.rootPage = browserPage
+            }
+        }
+    }
+
+    pageStack.onCurrentPageChanged: {
+        var currentContainer = pageStack._currentContainer
+        if (currentContainer && pageStack.currentPage !== window.rootPage) {
+            var index = findBackgroundIndexByPage(pageStack.currentPage)
+            if (index === -1) {
+                var background = backgroundComponent.createObject(window._wallpaperItem, {
+                                                                      "pageContainer": currentContainer,
+                                                                      "page": pageStack.currentPage
+                                                                  })
+                backgrounds.push({
+                                     "page": pageStack.currentPage,
+                                     "background": background
+                                 })
+            } else {
+                // Update container that is the one that moves.
+                backgrounds[index].background.pageContainer = currentContainer
+            }
         }
     }
 
@@ -47,5 +85,42 @@ ApplicationWindow {
         target: _coverWindow
         property: "mainWindow"
         value: webView
+    }
+
+    Component {
+        id: backgroundComponent
+        Browser.Background {
+            id: bg
+            property Item pageContainer
+            property Page page
+
+            // Page and attached background is destroyed when the page gets destroyed.
+            onPageChanged: {
+                if (!page) {
+                    var index = 0
+                    for (; index < backgrounds.length; ++index) {
+                        if (backgrounds[index].background === bg) {
+                            break
+                        }
+                    }
+
+                    if (index >= 0 && backgrounds.length > 0) {
+                        backgrounds.splice(index, 1)
+                    } else {
+                        backgrounds = []
+                    }
+
+                    destroy()
+                }
+            }
+
+            width: pageContainer ? pageContainer.width : 0
+            height: pageContainer ? pageContainer.height : 0
+            x: pageContainer && page && page.isPortrait ? pageContainer.x : 0
+            y: pageContainer && page && page.isLandscape ? pageContainer.y : 0
+            // Page can have longer life-cycle than page container in case
+            // page pushed to the pagestack as an item.
+            visible: pageContainer ? pageContainer.visible : 0
+        }
     }
 }

--- a/src/pages/ShareLinkPage.qml
+++ b/src/pages/ShareLinkPage.qml
@@ -11,8 +11,6 @@
 
 import QtQuick 2.0
 import Sailfish.Silica 1.0
-import Sailfish.Silica.private 1.0 as Private
-import "components" as Browser
 import Sailfish.TransferEngine 1.0
 
 Page {
@@ -20,15 +18,6 @@ Page {
 
     property string link
     property string linkTitle
-
-    orientationTransitions: Private.PageOrientationTransition {
-        fadeTarget: shareMethodList
-        targetPage: page
-    }
-
-    Browser.Background {
-        anchors.fill: parent
-    }
 
     ShareMethodList {
         id: shareMethodList

--- a/src/pages/components/ConfigDialog.qml
+++ b/src/pages/components/ConfigDialog.qml
@@ -12,17 +12,11 @@
 
 import QtQuick 2.2
 import Sailfish.Silica 1.0
-import Sailfish.Silica.private 1.0 as Private
 
 Dialog {
     id: configDialog
 
     property var changedConfigs: ({})
-
-    orientationTransitions: Private.PageOrientationTransition {
-        fadeTarget: prefsList
-        targetPage: configDialog
-    }
 
     // Get all the preferences
     Component.onCompleted: MozContext.sendObserve("embedui:allprefs", {})
@@ -70,10 +64,6 @@ Dialog {
 
     ListModel {
         id: filterListModel
-    }
-
-    Background {
-        anchors.fill: parent
     }
 
     SilicaListView {

--- a/src/pages/components/MultiSelectDialog.qml
+++ b/src/pages/components/MultiSelectDialog.qml
@@ -12,7 +12,6 @@
 
 import QtQuick 2.0
 import Sailfish.Silica 1.0
-import Sailfish.Silica.private 1.0 as Private
 
 Dialog {
     id: selectDialog
@@ -20,11 +19,6 @@ Dialog {
     // input data
     property var options
     property QtObject webview
-
-    orientationTransitions: Private.PageOrientationTransition {
-        fadeTarget: listView
-        targetPage: selectDialog
-    }
 
     onOpened: {
         for (var i=0; i < options.length; i++) {
@@ -54,10 +48,6 @@ Dialog {
         id: selectModel
 
         property int selectedIndex: -1
-    }
-
-    Background {
-        anchors.fill: parent
     }
 
     SilicaListView {

--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -77,7 +77,7 @@ Background {
 
     Private.VirtualKeyboardObserver {
         id: virtualKeyboardObserver
-        active: !overlayAnimator.atBottom
+        active: overlay.active && !overlayAnimator.atBottom
         orientation: browserPage.orientation
     }
 

--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -409,15 +409,6 @@ Background {
             id: tabPage
             property int activeTabIndex
 
-            orientationTransitions: Private.PageOrientationTransition {
-                fadeTarget: tabViewItem
-                targetPage: tabPage
-            }
-
-            Browser.Background {
-                anchors.fill: parent
-            }
-
             Browser.TabView {
                 id: tabViewItem
 

--- a/src/pages/components/PasswordManagerDialog.qml
+++ b/src/pages/components/PasswordManagerDialog.qml
@@ -11,7 +11,6 @@
 
 import QtQuick 2.0
 import Sailfish.Silica 1.0
-import Sailfish.Silica.private 1.0 as Private
 
 Dialog {
     id: passwordManagerDialog
@@ -21,11 +20,6 @@ Dialog {
     property string requestId
     property string notificationType
     property variant formData
-
-    orientationTransitions: Private.PageOrientationTransition {
-        fadeTarget: contentItem
-        targetPage: passwordManagerDialog
-    }
 
     onAccepted: {
         webView.sendAsyncMessage("embedui:login",
@@ -41,10 +35,6 @@ Dialog {
                                        "buttonidx": 1, // "No" button
                                        "id": requestId
                                    })
-    }
-
-    Background {
-        anchors.fill: parent
     }
 
     Item {

--- a/src/pages/components/SingleSelectPage.qml
+++ b/src/pages/components/SingleSelectPage.qml
@@ -12,7 +12,6 @@
 
 import QtQuick 2.0
 import Sailfish.Silica 1.0
-import Sailfish.Silica.private 1.0 as Private
 
 Page {
     id: selectPage
@@ -52,19 +51,10 @@ Page {
         }
     }
 
-    orientationTransitions: Private.PageOrientationTransition {
-        fadeTarget: listView
-        targetPage: selectPage
-    }
-
     ListModel {
         id: selectModel
 
         property int selectedIndex: -1
-    }
-
-    Background {
-        anchors.fill: parent
     }
 
     SilicaListView {

--- a/src/pages/components/UserPrompt.qml
+++ b/src/pages/components/UserPrompt.qml
@@ -11,22 +11,12 @@
 
 import QtQuick 2.0
 import Sailfish.Silica 1.0
-import Sailfish.Silica.private 1.0 as Private
 
 Dialog {
     id: dialog
     property alias acceptText: header.acceptText
     property alias title: header.title
     default property alias defaultContent: promptContent.children
-
-    orientationTransitions: Private.PageOrientationTransition {
-        fadeTarget: flickable
-        targetPage: dialog
-    }
-
-    Background {
-        anchors.fill: parent
-    }
 
     SilicaFlickable {
         id: flickable

--- a/src/pages/components/pickers/ContentPicker.qml
+++ b/src/pages/components/pickers/ContentPicker.qml
@@ -11,7 +11,6 @@
 
 import QtQuick 2.1
 import Sailfish.Pickers 1.0
-import ".." as Browser
 
 ContentPickerPage {
     property var creator
@@ -20,10 +19,4 @@ ContentPickerPage {
     //% "Upload file"
     title: qsTrId("sailfish_browser-he-upload_file")
     Component.onDestruction: creator.sendResponse(selectedContent)
-
-    _background: Component {
-        Browser.Background {
-            anchors.fill: parent
-        }
-    }
 }

--- a/src/pages/components/pickers/ImagePicker.qml
+++ b/src/pages/components/pickers/ImagePicker.qml
@@ -11,7 +11,6 @@
 
 import QtQuick 2.1
 import Sailfish.Pickers 1.0
-import ".." as Browser
 
 ImagePickerPage {
     property var creator
@@ -20,10 +19,4 @@ ImagePickerPage {
     //% "Upload image"
     title: qsTrId("sailfish_browser-he-upload_image")
     Component.onDestruction: creator.sendResponse(selectedContent)
-
-    _background: Component {
-        Browser.Background {
-            anchors.fill: parent
-        }
-    }
 }

--- a/src/pages/components/pickers/MultiContentPicker.qml
+++ b/src/pages/components/pickers/MultiContentPicker.qml
@@ -11,7 +11,6 @@
 
 import QtQuick 2.1
 import Sailfish.Pickers 1.0
-import ".." as Browser
 
 MultiContentPickerDialog {
     property var creator
@@ -20,10 +19,4 @@ MultiContentPickerDialog {
     //% "Upload files"
     title: qsTrId("sailfish_browser-he-upload_files")
     Component.onDestruction: creator.sendResponseList(selectedContent)
-
-    _background: Component {
-        Browser.Background {
-            anchors.fill: parent
-        }
-    }
 }

--- a/src/pages/components/pickers/MultiImagePicker.qml
+++ b/src/pages/components/pickers/MultiImagePicker.qml
@@ -11,7 +11,6 @@
 
 import QtQuick 2.1
 import Sailfish.Pickers 1.0
-import ".." as Browser
 
 MultiImagePickerDialog {
     property var creator
@@ -20,10 +19,4 @@ MultiImagePickerDialog {
     //% "Upload images"
     title: qsTrId("sailfish_browser-he-upload_images")
     Component.onDestruction: creator.sendResponseList(selectedContent)
-
-    _background: Component {
-        Browser.Background {
-            anchors.fill: parent
-        }
-    }
 }

--- a/src/pages/components/pickers/MultiMusicPicker.qml
+++ b/src/pages/components/pickers/MultiMusicPicker.qml
@@ -11,7 +11,6 @@
 
 import QtQuick 2.1
 import Sailfish.Pickers 1.0
-import ".." as Browser
 
 MultiMusicPickerDialog {
     property var creator
@@ -20,10 +19,4 @@ MultiMusicPickerDialog {
     //% "Upload audio files"
     title: qsTrId("sailfish_browser-he-upload_audio_files")
     Component.onDestruction: creator.sendResponseList(selectedContent)
-
-    _background: Component {
-        Browser.Background {
-            anchors.fill: parent
-        }
-    }
 }

--- a/src/pages/components/pickers/MultiVideoPicker.qml
+++ b/src/pages/components/pickers/MultiVideoPicker.qml
@@ -11,7 +11,6 @@
 
 import QtQuick 2.1
 import Sailfish.Pickers 1.0
-import ".." as Browser
 
 MultiVideoPickerDialog {
     property var creator
@@ -20,10 +19,4 @@ MultiVideoPickerDialog {
     //% "Upload videos"
     title: qsTrId("sailfish_browser-he-upload_videos")
     Component.onDestruction: creator.sendResponseList(selectedContent)
-
-    _background: Component {
-        Browser.Background {
-            anchors.fill: parent
-        }
-    }
 }

--- a/src/pages/components/pickers/MusicPicker.qml
+++ b/src/pages/components/pickers/MusicPicker.qml
@@ -11,7 +11,6 @@
 
 import QtQuick 2.1
 import Sailfish.Pickers 1.0
-import ".." as Browser
 
 MusicPickerPage {
     property var creator
@@ -20,10 +19,4 @@ MusicPickerPage {
     //% "Upload audio file"
     title: qsTrId("sailfish_browser-he-upload_audio")
     Component.onDestruction: creator.sendResponse(selectedContent)
-
-    _background: Component {
-        Browser.Background {
-            anchors.fill: parent
-        }
-    }
 }

--- a/src/pages/components/pickers/VideoPicker.qml
+++ b/src/pages/components/pickers/VideoPicker.qml
@@ -11,7 +11,6 @@
 
 import QtQuick 2.1
 import Sailfish.Pickers 1.0
-import ".." as Browser
 
 VideoPickerPage {
     property var creator
@@ -20,10 +19,4 @@ VideoPickerPage {
     //% "Upload video"
     title: qsTrId("sailfish_browser-he-upload_video")
     Component.onDestruction: creator.sendResponse(selectedContent)
-
-    _background: Component {
-        Browser.Background {
-            anchors.fill: parent
-        }
-    }
 }


### PR DESCRIPTION
Review @rojkov @mikkoharju 

Sharing via email and selecting contact ended up being tough nut to crack but now that works as well.

Also sharing via email and picking attachments is working and as well as "normal" facebook like sharing. This doesn't contain external dependencies.

Same approach will be automatically used for web prompts, password manager dialogs, etc.
