### PR TITLE
[sailfish-browser] Open keyboard of first time use. Fixes JB#29683

### DIFF
--- a/src/declarativewebcontainer.cpp
+++ b/src/declarativewebcontainer.cpp
@@ -485,7 +485,6 @@ bool DeclarativeWebContainer::eventFilter(QObject *obj, QEvent *event)
             context.doneCurrent();
             m_hasBeenExposed = true;
             m_windowExposed.wakeAll();
-
         } else if (!isExposed() && !m_allowHiding) {
             return true;
         }
@@ -494,6 +493,15 @@ bool DeclarativeWebContainer::eventFilter(QObject *obj, QEvent *event)
         // after the window has been closed.
         m_webPage->suspendView();
     }
+
+    // Emit chrome exposed when both chrome window and browser window has been exposed. This way chrome
+    // window can be raised to the foreground if needed.
+    static bool hasExposedChrome = false;
+    if (!hasExposedChrome && event->type() == QEvent::Show && m_chromeWindow && m_chromeWindow->isExposed() && isExposed()) {
+        emit chromeExposed();
+        hasExposedChrome = true;
+    }
+
     return QObject::eventFilter(obj, event);
 }
 

--- a/src/declarativewebcontainer.h
+++ b/src/declarativewebcontainer.h
@@ -159,6 +159,7 @@ signals:
 
     void webPageComponentChanged();
     void chromeWindowChanged();
+    void chromeExposed();
 
 protected:
     bool eventFilter(QObject *obj, QEvent *event);

--- a/src/pages/BrowserPage.qml
+++ b/src/pages/BrowserPage.qml
@@ -38,16 +38,16 @@ Page {
         webView.load(url, title)
     }
 
-    function bringToForeground() {
-        if (!Qt.application.active) {
-            webView.raise()
+    function bringToForeground(window) {
+        if (!Qt.application.active && window) {
+            window.raise()
         }
     }
 
     function activateNewTabView() {
         pageStack.pop(browserPage, PageStackAction.Immediate);
         overlay.enterNewTabUrl(PageStackAction.Immediate)
-        bringToForeground()
+        bringToForeground(webView.chromeWindow)
         // after bringToForeground, webView has focus => activate chrome
         window.activate()
     }
@@ -155,6 +155,12 @@ Page {
 
         tabModel.onCountChanged: window.opaqueBackground = tabModel.count == 0
 
+        onChromeExposed: {
+            if (overlay.animator.atTop && overlay.searchField.focus && !WebUtils.firstUseDone) {
+                webView.chromeWindow.raise()
+            }
+        }
+
         function applyContentOrientation(orientation) {
             switch (orientation) {
             case Orientation.None:
@@ -259,7 +265,7 @@ Page {
             // Url is empty when user tapped icon when browser was already open.
             // In case first use not done show the overlay immediately.
             if (url == "") {
-                bringToForeground()
+                bringToForeground(webView.chromeWindow)
                 if (!WebUtils.firstUseDone) {
                     overlay.animator.showOverlay(true)
                 }
@@ -277,7 +283,7 @@ Page {
                 webView.load(url)
                 overlay.animator.showChrome(true)
             }
-            bringToForeground()
+            bringToForeground(webView)
         }
         onActivateNewTabViewRequested: {
             activateNewTabView()

--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -26,6 +26,7 @@ Background {
     property alias progressBar: progressBar
     property alias animator: overlayAnimator
     property alias dragArea: dragArea
+    property alias searchField: searchField
     readonly property alias enteringNewTabUrl: searchField.enteringNewTabUrl
 
     property var enteredPage


### PR DESCRIPTION
Remove .firstUseDone marker file from
/home/nemo/.local/share/org.sailfishos/sailfish-browser and close
all tabs and restart browser.
