### PR TITLE
[sailfish-browser] Keep dimmer visible when creating tab. Fixes JB#29526

### DIFF
--- a/src/browser.qml
+++ b/src/browser.qml
@@ -22,7 +22,6 @@ ApplicationWindow {
 
     property bool opaqueBackground
     property var rootPage
-
     property var backgrounds: []
 
     function setBrowserCover(model) {

--- a/src/declarativetabmodel.cpp
+++ b/src/declarativetabmodel.cpp
@@ -70,8 +70,6 @@ void DeclarativeTabModel::addTab(const QString& url, const QString &title) {
 
     m_nextTabId = ++tabId;
     emit nextTabIdChanged();
-
-    setWaitingForNewTab(false);
 }
 
 int DeclarativeTabModel::nextTabId() const
@@ -116,7 +114,7 @@ void DeclarativeTabModel::clear()
         removeTab(m_tabs.at(i).tabId(), m_tabs.at(i).thumbnailPath(), i);
     }
 
-    setWaitingForNewTab(false);
+    setWaitingForNewTab(true);
 }
 
 bool DeclarativeTabModel::activateTab(const QString& url)
@@ -337,6 +335,8 @@ void DeclarativeTabModel::updateActiveTab(const Tab &activeTab, bool loadActiveT
     if (m_activeTab != activeTab) {
         int oldTabId = m_activeTab.tabId();
         m_activeTab = activeTab;
+
+        setWaitingForNewTab(true);
 
         // If tab has changed, update active tab role.
         int tabIndex = activeTabIndex();

--- a/src/declarativewebcontainer.h
+++ b/src/declarativewebcontainer.h
@@ -68,6 +68,7 @@ class DeclarativeWebContainer : public QWindow, public QQmlParserStatus, protect
     Q_PROPERTY(QString url READ url NOTIFY urlChanged FINAL)
 
     Q_PROPERTY(bool privateMode READ privateMode WRITE setPrivateMode NOTIFY privateModeChanged FINAL)
+    Q_PROPERTY(bool activeTabRendered READ activeTabRendered NOTIFY activeTabRenderedChanged FINAL)
 
     Q_PROPERTY(QQmlComponent* webPageComponent MEMBER m_webPageComponent NOTIFY webPageComponentChanged FINAL)
     Q_PROPERTY(QObject *chromeWindow READ chromeWindow WRITE setChromeWindow NOTIFY chromeWindowChanged FINAL)
@@ -90,6 +91,8 @@ public:
 
     bool privateMode() const;
     void setPrivateMode(bool);
+
+    bool activeTabRendered();
 
     bool loading() const;
 
@@ -156,6 +159,7 @@ signals:
     void urlChanged();
     void thumbnailPathChanged();
     void privateModeChanged();
+    void activeTabRenderedChanged();
 
     void webPageComponentChanged();
     void chromeWindowChanged();
@@ -193,6 +197,7 @@ private slots:
     void onPageTitleChanged();
     void updateLoadProgress();
     void updateLoading();
+    void updateActiveTabRendered();
     void setActiveTabData();
 
     void updateWindowFlags();
@@ -214,6 +219,7 @@ private:
     bool canInitialize() const;
     void loadTab(int tabId, QString url, QString title, bool force);
     void updateMode();
+    void setActiveTabRendered(bool rendered);
 
     QPointer<QQuickItem> m_rotationHandler;
     QPointer<DeclarativeWebPage> m_webPage;
@@ -262,6 +268,7 @@ private:
     bool m_initialized;
 
     bool m_privateMode;
+    bool m_activeTabRendered;
     bool m_hasBeenExposed;
 
     QMutex m_exposedMutex;

--- a/src/pages/components/Background.qml
+++ b/src/pages/components/Background.qml
@@ -30,7 +30,10 @@ Item {
             anchors.fill: parent
             color: "white"
             opacity: window.opaqueBackground ? 1 : 0
-            Behavior on opacity { FadeAnimation { } }
+            Behavior on opacity {
+                enabled: window.rootPage.active
+                FadeAnimation { }
+            }
         }
 
         Rectangle {

--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -52,7 +52,6 @@ Background {
                 }
                 webView.tabModel.waitingForNewTab = true
             }
-            //webView.focus = true
         }
 
         overlayAnimator.showChrome()


### PR DESCRIPTION
Keep content dimmer visible after tab is changed until
a frame is rendered for the active tab.

Input handling is kept on the chrome window while content dimmer
is visible.
