### PR TITLE
Redirect mouse input to chrome window while download remorse popup is visible

### DIFF
--- a/src/pages/BrowserPage.qml
+++ b/src/pages/BrowserPage.qml
@@ -55,7 +55,7 @@ Page {
     function inputMaskForOrientation(orientation) {
         // mask is in portrait window coordinates
         var mask = Qt.rect(0, 0, Screen.width, Screen.height)
-        if (!window.opaqueBackground && webView.enabled && browserPage.active && !webView.popupActive) {
+        if (!window.opaqueBackground && webView.enabled && browserPage.active && !webView.popupActive && !downloadPopup.visible) {
             var overlayVisibleHeight = browserPage.height - overlay.y
 
             switch (orientation) {


### PR DESCRIPTION
As we can't have two separate InputRegions for the popup and overlay then it probably makes sense to redirect mouse input to the whole chrome window.
