### PR TITLE
[sailfish-browser] Fix build error when using build.sh script.

### DIFF
--- a/tests/auto/common/declarativewebutils_mock.pri
+++ b/tests/auto/common/declarativewebutils_mock.pri
@@ -5,4 +5,8 @@
 SOURCES += ../common/declarativewebutils.cpp
 HEADERS += ../common/declarativewebutils.h
 
-PKGCONFIG += qt5embedwidget
+isEmpty(QTEMBED_LIB) {
+  PKGCONFIG += qt5embedwidget
+} else {
+  LIBS+=$$QTEMBED_LIB
+}


### PR DESCRIPTION
In case the browser is build using build.sh from xulrunnre-packaging
don't rely on pkgconfig for finding qtmozembed.
